### PR TITLE
fix parsing error in fixrefs

### DIFF
--- a/src/Calc.jl
+++ b/src/Calc.jl
@@ -330,7 +330,7 @@ function initiate_calc_repl(repl)
             return s
         end
         n = try
-            parse(st[2:end])
+            Meta.parse(st[2:end])
         catch
             ""
         end


### PR DESCRIPTION
the symbols for stacked values were not detected properly, causing errors.